### PR TITLE
support prometheus-operator podMonitor resource

### DIFF
--- a/charts/eks-fluentd-s3/Chart.yaml
+++ b/charts/eks-fluentd-s3/Chart.yaml
@@ -14,7 +14,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.3
+version: 0.1.4
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/charts/eks-fluentd-s3/templates/configmap.yaml
+++ b/charts/eks-fluentd-s3/templates/configmap.yaml
@@ -2,8 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ template "eks-fluentd-s3.fullname" . }} 
-  labels:
-    chart: {{ template "eks-fluentd-s3.chart" . }} 
+  labels: {{ include "eks-fluentd-s3.labels" . | nindent 4 }}
 data:
   S3_BUCKET_NAME: "{{ .Values.s3.bucket_name }}"
   S3_BUCKET_PREFIX: "{{ .Values.s3.bucket_prefix }}"

--- a/charts/eks-fluentd-s3/templates/daemonset.yaml
+++ b/charts/eks-fluentd-s3/templates/daemonset.yaml
@@ -1,15 +1,14 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: DaemonSet
 metadata:
   name: {{ template "eks-fluentd-s3.fullname" . }}
-  labels:
-    k8s-app: {{ template "eks-fluentd-s3.fullname" . }}
-    chart: {{ template "eks-fluentd-s3.chart" . }} 
+  labels: {{ include "eks-fluentd-s3.labels" . | nindent 4 }}
 spec:
+  selector:
+    matchLabels: {{ include "eks-fluentd-s3.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      labels:
-        app: {{ template "eks-fluentd-s3.fullname" . }}
+      labels: {{ include "eks-fluentd-s3.labels" . | nindent 8 }}
     spec:
       serviceAccountName: {{ template "eks-fluentd-s3.fullname" . }}
       tolerations:
@@ -24,6 +23,9 @@ spec:
             name: {{ template "eks-fluentd-s3.fullname" . }}
         args:
         - --use-v1-config
+        ports:
+        - name: metrics
+          containerPort: {{ .Values.prometheus.port }}
         resources:
           limits:
             memory: 200Mi

--- a/charts/eks-fluentd-s3/templates/service-account.yaml
+++ b/charts/eks-fluentd-s3/templates/service-account.yaml
@@ -2,8 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ template "eks-fluentd-s3.fullname" . }} 
-  labels:
-    app: {{ template "eks-fluentd-s3.fullname" . }} 
-    chart: {{ template "eks-fluentd-s3.chart" . }} 
+  labels: {{ include "eks-fluentd-s3.labels" . | nindent 4 }}
   annotations:
     eks.amazonaws.com/role-arn: "{{ .Values.s3.role_arn }}"

--- a/charts/eks-fluentd-s3/templates/service-monitor.yaml
+++ b/charts/eks-fluentd-s3/templates/service-monitor.yaml
@@ -1,0 +1,25 @@
+{{- if .Values.prometheus.service_monitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ template "eks-fluentd-s3.fullname" . }}
+  {{- with .Values.prometheus.service_monitor.namespace }}
+  namespace: {{ . }}
+  {{- end }}
+  labels: {{ include "eks-fluentd-s3.labels" . | nindent 4 }}
+spec:
+  podMetricsEndpoints:
+    - port: metrics
+      path: {{ .Values.prometheus.path }}
+      {{- with .Values.prometheus.service_monitor.interval }}
+      interval: {{ . }}
+      {{- end }}
+      {{- with .Values.prometheus.service_monitor.scrape_timeout }}
+      scrapeTimeout: {{ . }}
+      {{- end }}
+  namespaceSelector:
+    matchNames:
+      - {{ .Release.Namespace }}
+  selector:
+    matchLabels: {{ include "eks-fluentd-s3.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/eks-fluentd-s3/values.yaml
+++ b/charts/eks-fluentd-s3/values.yaml
@@ -8,6 +8,11 @@ prometheus:
   bind: '0.0.0.0'
   port: '24231'
   path: '/metrics'
+  service_monitor:
+    enabled: false
+    interval: 10s
+    scrape_timeout: 6s
+    namespace: prometheus
 k8s:
   parser_type: 'json'
   api_url: ''


### PR DESCRIPTION
* Adds an optional PodMonitor resource that is used by the Prometheus Operator to know what to scrape
* Upgrade daemonset API version to `apps/v1`
* Use the built-in helm labels helpers
* Explicitly define the metrics port in the daemonset